### PR TITLE
Fix DB connection env var

### DIFF
--- a/database/mysql.js
+++ b/database/mysql.js
@@ -5,7 +5,7 @@ const pool = mysql.createPool({
     host: process.env.DB_HOST,
     user: process.env.DB_USER,
     password: process.env.DB_PASSWORD,
-    database: process.env.DB_DATABASE,
+    database: process.env.DB_NAME,
     waitForConnections: true,
     connectionLimit: 10,
     queueLimit: 0


### PR DESCRIPTION
## Summary
- use `DB_NAME` env var in mysql config

## Testing
- `npm test` *(fails: no test specified)*
- `node index.js` *(fails: cannot find module 'dotenv' due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68755c30befc832e8add9b83d13efd03