### PR TITLE
Add web leaderboard and dashboard slash command

### DIFF
--- a/commands/util/dashboard.js
+++ b/commands/util/dashboard.js
@@ -1,0 +1,12 @@
+const { SlashCommandBuilder } = require('discord.js');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('dashboard')
+        .setDescription('Sendet dir den Link zum Web-Dashboard'),
+
+    async execute(interaction) {
+        const url = process.env.DASHBOARD_URL || 'http://localhost:3000';
+        await interaction.reply({ content: `\uD83C\uDF10 Dashboard: ${url}`, ephemeral: true });
+    }
+};

--- a/web/server.js
+++ b/web/server.js
@@ -9,6 +9,7 @@ const DiscordStrategy = require('passport-discord').Strategy;
 const path = require('path');
 const dashboardRoutes = require('./routes/dashboard');
 const settingsApi = require('./routes/api/settings');
+const economy = require('../database/economy');
 
 const app = express();
 const PORT = process.env.DASHBOARD_PORT || 3000;
@@ -94,6 +95,24 @@ app.get('/commands', async (req, res) => {
       user: req.user,
       commands: [],
       error: "Fehler beim Laden der Befehle"
+    });
+  }
+});
+
+// 🔝 Öffentliche Rangliste
+app.get('/leaderboard', async (req, res) => {
+  try {
+    const topUsers = await economy.getTopUsers();
+    res.render('leaderboard', {
+      user: req.user,
+      topUsers
+    });
+  } catch (err) {
+    console.error('Fehler beim Laden des Leaderboards:', err);
+    res.render('leaderboard', {
+      user: req.user,
+      topUsers: [],
+      error: 'Fehler beim Laden der Rangliste'
     });
   }
 });

--- a/web/views/dashboard/commands.ejs
+++ b/web/views/dashboard/commands.ejs
@@ -17,6 +17,7 @@
       <li><a href="/">🏠 Home</a></li>
       <li><a href="/dashboard">📊 Übersicht</a></li>
       <li><a href="/dashboard/commands">📖 Befehle</a></li>
+      <li><a href="/leaderboard">🏆 Rangliste</a></li>
       <li><a href="/logout">🚪 Logout</a></li>
     </ul>
     <button class="hamburger" onclick="toggleNav()">☰</button>

--- a/web/views/dashboard/guild.ejs
+++ b/web/views/dashboard/guild.ejs
@@ -33,6 +33,7 @@
       
           <li><a href="/dashboard" class="nav-link">🔙 Zurück</a></li>
           <li><a href="/dashboard/commands" class="nav-link">📖 Befehle</a></li>
+          <li><a href="/leaderboard" class="nav-link">🏆 Rangliste</a></li>
         </ul>
       </nav>
       

--- a/web/views/dashboard/index.ejs
+++ b/web/views/dashboard/index.ejs
@@ -17,6 +17,7 @@
       <li><a href="/">🏠 Home</a></li>
       <li><a href="/dashboard">📊 Übersicht</a></li>
       <li><a href="/commands">📖 Befehle</a></li>
+      <li><a href="/leaderboard">🏆 Rangliste</a></li>
       <li><a href="/logout">🚪 Logout</a></li>
     </ul>
     <button class="hamburger" onclick="toggleNav()">☰</button>

--- a/web/views/dashboard/tickets.ejs
+++ b/web/views/dashboard/tickets.ejs
@@ -12,6 +12,8 @@
     <ul class="nav-links">
       <li><a href="/">🏠 Home</a></li>
       <li><a href="/dashboard">📊 Übersicht</a></li>
+      <li><a href="/dashboard/commands">📖 Befehle</a></li>
+      <li><a href="/leaderboard">🏆 Rangliste</a></li>
       <li><a href="/logout">🚪 Logout</a></li>
     </ul>
   </nav>

--- a/web/views/dashboard/tickets_settings.ejs
+++ b/web/views/dashboard/tickets_settings.ejs
@@ -12,6 +12,8 @@
       <li><a href="/">🏠 Home</a></li>
       <li><a href="/dashboard/<%= guild.id %>/tickets">🎫 Tickets</a></li>
       <li><a href="/dashboard/<%= guild.id %>/settings/tickets">⚙️ Ticket Einstellungen</a></li>
+      <li><a href="/dashboard/commands">📖 Befehle</a></li>
+      <li><a href="/leaderboard">🏆 Rangliste</a></li>
       <li><a href="/dashboard">🔙 Zurück</a></li>
     </ul>
   </nav>

--- a/web/views/home.ejs
+++ b/web/views/home.ejs
@@ -22,6 +22,7 @@
     <div class="nav-links" id="navbarLinks">
       <a href="/">🏠 Home</a>
       <a href="/commands">📖 Befehle</a>
+      <a href="/leaderboard">🏆 Rangliste</a>
       <% if (user) { %>
         <a href="/dashboard">📊 Dashboard</a>
         <a href="/logout">🚪 Logout</a>

--- a/web/views/leaderboard.ejs
+++ b/web/views/leaderboard.ejs
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <title>🏆 Rangliste</title>
+  <link rel="stylesheet" href="/css/home.css">
+  <script defer src="/js/navbar.js"></script>
+  <link rel="shortcut icon" href="/img/logo.png" type="image/x-icon">
+</head>
+<body>
+  <nav class="navbar">
+    <h1>🚀 OPBot Dashboard</h1>
+    <div class="hamburger" onclick="toggleMenu()">
+      <span></span><span></span><span></span>
+    </div>
+    <div class="nav-links" id="navbarLinks">
+      <a href="/">🏠 Home</a>
+      <a href="/commands">📖 Befehle</a>
+      <a href="/leaderboard">🏆 Rangliste</a>
+      <% if (user) { %>
+        <a href="/dashboard">📊 Dashboard</a>
+        <a href="/logout">🚪 Logout</a>
+      <% } else { %>
+        <a href="/auth/discord">🔐 Login</a>
+      <% } %>
+    </div>
+  </nav>
+
+  <main class="container">
+    <h2>🏆 Top 10 Nutzer</h2>
+    <table class="leaderboard">
+      <tr><th>Platz</th><th>User</th><th>Coins</th></tr>
+      <% topUsers.forEach((u, i) => { %>
+        <tr>
+          <td><%= i + 1 %></td>
+          <td><%= `<@${u.user_id}>` %></td>
+          <td><%= u.balance.toLocaleString() %></td>
+        </tr>
+      <% }) %>
+    </table>
+    <% if (error) { %>
+      <p><%= error %></p>
+    <% } %>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- show dashboard link via new `/dashboard` slash command
- list top economy users in a new `leaderboard` web page
- update navigation links for the new route
- wire up `/leaderboard` route in the web server

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68755f7065ec832e996bd36638286891